### PR TITLE
support sequel's STI model_map functionality

### DIFF
--- a/lib/fixture_dependencies.rb
+++ b/lib/fixture_dependencies.rb
@@ -154,7 +154,14 @@ class << FixtureDependencies
       loading.pop
       return existing_obj
     end
-    obj = model.respond_to?(:sti_key) ? attributes[model.sti_key].to_s.camelize.constantize.new : model.new
+    if model.respond_to?(:sti_load)
+      obj = model.sti_load(model.sti_key => attributes[model.sti_key])
+      obj.send(:initialize)
+    elsif model.respond_to?(:sti_key)
+      obj = attributes[model.sti_key].to_s.camelize.constantize.new
+    else
+      obj = model.new
+    end
     puts "#{spaces}#{model} STI plugin detected, initializing instance of #{obj}" if (verbose > 1 && model.respond_to?(:sti_dataset))
     many_associations = []
     attributes.each do |attr, value|


### PR DESCRIPTION
Previously, fixture-dependencies assumed the value in the :sti_key column
was the class name.  This patch delegates the loading of the sub-class to
the :sti_load method in the STI plugin class.
