### PR TITLE
Support pre-4.24.0 CTI in Sequel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-= fixture_dependencies
+# fixture_dependencies
 
 fixture_dependencies is an advanced fixture loader, allowing the loading of
 models from YAML fixtures, along with their entire dependency graph.  It has
@@ -16,73 +16,91 @@ the following features:
   helper for RSpec) that load fixtures for every test inside a transaction,
   so fixture data is never left in your database
 
-== Installation
+## Installation
 
+```
   gem install fixture_dependencies
-    
-== Source
+```
+
+## Source
 
 Source is available via github:
 
+```
   http://github.com/jeremyevans/fixture_dependencies
+```
 
 You can check it out with git:
 
+```
   git clone git://github.com/jeremyevans/fixture_dependencies.git
+```
 
-== Usage
+## Usage
 
-=== With Rails/ActiveRecord/Test::Unit:
+### With Rails/ActiveRecord/Test::Unit:
 
 Add the following to test/test_helper.rb after "require 'test_help'":
 
+```
   require 'fixture_dependencies/test_unit/rails'
+```
 
 This overrides the default test helper to load the fixtures inside transactions
 and to use FixtureDependencies to load the fixtures.
 
-=== With Sequel/Test::Unit:
+### With Sequel/Test::Unit:
 
 Somewhere before the test code is loaded:
 
+```
   require 'fixture_dependencies/test_unit/sequel'
-  
+```
+
 Make sure the test case classes use FixtureDependencies::SequelTestCase:
 
+```
   class ModelTest < FixtureDependencies::SequelTestCase
+```
 
 This runs the test cases inside a Sequel transaction.
 
-=== With Sequel/RSpec:
+### With Sequel/RSpec:
 
 Somewhere before the test code is loaded:
 
+```
   require 'fixture_dependencies/rspec/sequel'
-  
+```
+
 This runs each spec inside a separate Sequel transaction.
 
-=== With other testing libraries:
+### With other testing libraries:
 
 You can just use FixtureDependencies.load to handle the loading of fixtures.
 The use of transactions is up to you.  One thing you must do if you are
 not using the rails test helper is to set the fixture path for
 FixtureDependencies:
 
+```
   FixtureDependencies.fixture_path = '/path/to/fixtures'
+```
 
-== Changes to Rails default fixtures:
+## Changes to Rails default fixtures:
 
 fixture_dependencies is designed to require the least possible changes to
 the default YAML fixtures used by Rails (well, at least Rails 1.2 and earlier).
 For example, see the following changes:
 
+```
   OLD                       NEW
   asset1:                   asset1:
-    id: 1                     id: 1
-    employee_id: 2            employee: jeremy
-    product_id: 3             product: nx7010
-    vendor_id: 2              vendor: lxg_computers
-    note: in working order    note: in working order                
+  id: 1                     id: 1
+  employee_id: 2            employee: jeremy
+  product_id: 3             product: nx7010
+  vendor_id: 2              vendor: lxg_computers
+  note: in working order    note: in working order
+```
 
 As you can see, you just replace the foreign key attribute and value with the
 name of the association and the associations name.  This assumes you have an
@@ -93,7 +111,7 @@ Fixture files still use the table_name of the model. Note that you make sure
 to hard code primary key values for each fixture, as shown in the example
 above.
 
-== ERB Fixtures
+## ERB Fixtures
 
 Fixtures can also use ERB to preprocess the fixture file, useful if you need
 to do any programming inside the fixture file, such as looping to create
@@ -103,13 +121,15 @@ mix ERB fixture files and regular fixture files, but you can not have an
 ERB fixture file and a regular fixture file for the same table (the regular
 fixture file will be used in that case).
 
-== Changes to the fixtures Class Method:
+## Changes to the fixtures Class Method:
 
 fixture_dependencies can still use the fixtures class method in your test:
 
+```
   class EmployeeTest < Test::Unit::TestCase
     fixtures :assets
   end
+```
 
 In Rails default testing practices, the arguments to fixtures are table names.
 fixture_dependencies changes this to underscored model names.  If you are using
@@ -119,39 +139,42 @@ It is recommended that you do not use the fixtures method, and instead load
 individual fixtures as needed (see below).  This makes your tests much more
 robust, in case you want to add or remove individual fixtures at a later date.
 
-== Loading individual fixtures with fixtures class method
+## Loading individual fixtures with fixtures class method
 
 There is support for loading individual fixtures (and just their dependencies),
 using the following syntax:
 
+```
   class EmployeeTest < Test::Unit::TestCase
     fixtures :employee__jeremy # Note the double underscore
   end
-  
+```
+
 This would load just the jeremy fixture and its dependencies.  I find this is
 much better than loading all fixtures in most of my test suites.  Even better
 is loading just the fixtures you want inside every test method (see below).
 This leads to the most robust testing.
 
-== Loading fixtures inside test methods
+## Loading fixtures inside test methods
 
 I find that it is often better to skip the use of the fixtures method entirely,
 and load the fixtures I want manually in each test method.  This provides for
 the loosest coupling possible.  Here's an example:
 
+```
   class EmployeeTest < Test::Unit::TestCase
     def test_employee_name
       # Load the fixture and return the Employee object
       employee = load(:employee__jeremy)
       # Test the employee
     end
-    
+
     def test_employees
       # Load the fixtures and return two Employee objects
       employee1, employee2 = load(:employees=>[:jeremy, :karl])
       # Test the employees
     end
-    
+
     def test_award_statistics
       #  Load all fixtures in both tables
       load(:employee_award__jeremy_first, :award__first)
@@ -159,55 +182,58 @@ the loosest coupling possible.  Here's an example:
       #  (which pulls data from the tables loaded above)
     end
   end
+```
 
 Don't worry about loading the same fixture twice, if a fixture is already
 loaded, it won't attempt to load it again.
 
-== one_to_many/many_to_many/has_many/has_and_belongs_to_many assocations
+## one_to_many/many_to_many/has_many/has_and_belongs_to_many assocations
 
 Here's an example of using has_one (logon_information), has_many (assets), and
 has_and_belongs_to_many (groups) associations.
 
+```
   jeremy:
-    id: 2
-    name: Jeremy Evans
-    logon_information: jeremy
-    assets: [asset1, asset2, asset3]
-    groups: [group1]
+  id: 2
+  name: Jeremy Evans
+  logon_information: jeremy
+  assets: [asset1, asset2, asset3]
+  groups: [group1]
+```
 
-logon_information is a has_one association to another table which was split
+`logon_information` is a has_one association to another table which was split
 from the employees table due to database security requirements.  Assets is a
 has_many association, where one employee is responsible for the asset.
 Employees can be a member of multiple groups, and each group can have multiple
 employees.
 
-For has_* associations, after fixture_dependencies saves jeremy, it will load
+For `has_*` associations, after fixture_dependencies saves jeremy, it will load
 and save logon_information (and its dependencies...), it will load each asset
 in the order specified (and their dependencies...), and it will load all of the
 groups in the order specified (and their dependencies...).  Note that there
 is only a load order inside a specific association, associations are stored
 in the same hash as attributes and are loaded in an arbitrary order.
 
-== many_to_many/has_and_belongs_to_many join table fixtures
+## many_to_many/has_and_belongs_to_many join table fixtures
 
 Another change is that Rails defaults allow you to specify habtm join tables in
 fixtures.  That doesn't work with fixture dependencies, as there is no
 associated model.  Instead, you use a has_and_belongs_to_many association name
 in the the appropriate model fixtures (see above).
 
-== Cyclic dependencies
+## Cyclic dependencies
 
 fixture_dependencies handles almost all cyclic dependencies.  It handles all
 has_many, has_one, and habtm cyclic dependencies.  It handles all
 self-referential cyclic dependencies.  It handles all belongs_to cyclic
 dependencies except the case where there is a NOT NULL or validates_presence of
-constraint on the cyclic dependency's foreign key.  
+constraint on the cyclic dependency's foreign key.
 
 For example, a case that won't work is when employee belongs_to supervisor
 (with a NOT NULL or validates_presence_of constraint on supervisor_id), and
 john is karl's supervisor and karl is john's supervisor. Since you can't create
 john without a valid supervisor_id, you need to create karl first, but you
-can't create karl for the same reason (as john doesn't exist yet).  
+can't create karl for the same reason (as john doesn't exist yet).
 
 There isn't a generic way to handle the belongs_to cyclic dependency, as far as
 I know.  Deferring foreign key checks could work, but may not be enabled (and
@@ -220,7 +246,7 @@ division belongs_to head_of_division when the employee is a member of the
 division and also the head of the division), even that approach is not
 possible.
 
-== Known issues
+## Known issues
 
 Currently, the plugin only supports YAML fixtures, but other types of fixtures
 would be fairly easy to add (send me a patch if you add support for another
@@ -230,12 +256,12 @@ The plugin is significantly slower than the default testing method, because it
 loads all fixtures inside of a transaction (one per test method), where Rails
 defaults to loading the fixtures once per test suite (outside of a
 transaction), and only deletes fixtures from a table when overwriting it with
-new fixtures.  
+new fixtures.
 
 Instantiated fixtures are not available with this plugin.  Instead, you should
 use load(:model__fixture_name).
 
-== Namespace Issues
+## Namespace Issues
 
 By default, fixture dependencies is going to load the model with the camelized
 name in the symbol used.  So for :foo_bar__baz, it's going to look for
@@ -243,30 +269,34 @@ the fixture with name baz for the model FooBar.  If your model is namespaced,
 such as Foo::Bar, this isn't going to work well.  In that case, you can
 override the default mapping:
 
+```
   FixtureDependencies.class_map[:bar] = Foo::Bar
+```
 
 and then use :bar__baz to load the fixture with name baz for the model
 Foo::Bar.
 
-== Troubleshooting
+## Troubleshooting
 
 If you run into problems with loading your fixtures, it can be difficult to see
-where the problems are.  To aid in debugging an error, add the following to 
+where the problems are.  To aid in debugging an error, add the following to
 test/test_helper.rb:
 
+```
   FixtureDependencies.verbose = 3
-  
+```
+
 This will give a verbose description of the loading and saving of fixtures for
 every test, including the recursive loading of the dependency graph.
 
-== Specs
+## Specs
 
 The specs for fixture dependencies and be run with Rake.  They require
 the sequel, activerecord, and sqlite3 gems installed.  The default rake task
 runs the specs.  You should run the spec_migrate task first to create the
 spec database.
 
-== Similar Ideas
+## Similar Ideas
 
 Rails now supports something similar by default.  Honestly, I'm not sure what
 the differences are.
@@ -275,11 +305,11 @@ fixture_references is a similar plugin.  It uses erb inside yaml, and uses the
 foreign key numbers inside of the association names, which leads me to believe
 it doesn't support has_* associations.
 
-== License
+## License
 
 fixture_dependencies is released under the MIT License.  See the MIT-LICENSE
 file for details.
 
-== Author
+## Author
 
 Jeremy Evans <code@jeremyevans.net>

--- a/lib/fixture_dependencies.rb
+++ b/lib/fixture_dependencies.rb
@@ -166,17 +166,17 @@ class << FixtureDependencies
     if model.respond_to?(:sti_load)
       obj = model.sti_load(model.sti_key => attributes[model.sti_key])
       obj.send(:initialize)
+      model = obj.model
     elsif model.respond_to?(:sti_key)
       obj = attributes[model.sti_key].to_s.camelize.constantize.new
     elsif model.respond_to?(:cti_key) # support for Sequel's pre-4.24.0 hybrid CTI support
       mv = attributes[model.cti_key]
       if (mm = model.cti_model_map)
-        obj = mm[mv].to_s.constantize.new
-      elsif mv.nil?
-        obj = model.new
-      else
-        obj = mv.constantize.new
+        model = mm[mv].to_s.constantize
+      elsif !mv.nil?
+        model = mv.constantize
       end
+      obj = model.new
     else
       obj = model.new
     end

--- a/lib/fixture_dependencies.rb
+++ b/lib/fixture_dependencies.rb
@@ -168,6 +168,15 @@ class << FixtureDependencies
       obj.send(:initialize)
     elsif model.respond_to?(:sti_key)
       obj = attributes[model.sti_key].to_s.camelize.constantize.new
+    elsif model.respond_to?(:cti_key) # support for Sequel's pre-4.24.0 hybrid CTI support
+      mv = attributes[model.cti_key]
+      if (mm = model.cti_model_map)
+        obj = mm[mv].to_s.constantize.new
+      elsif mv.nil?
+        obj = model.new
+      else
+        obj = mv.constantize.new
+      end
     else
       obj = model.new
     end

--- a/spec/fd_spec.rb
+++ b/spec/fd_spec.rb
@@ -13,7 +13,7 @@ describe FixtureDependencies do
 
   after do
     # Clear tables and fixture_dependencies caches
-    [:stis, :com_self_refs, :com_albums_com_tags, :com_tags, :com_albums, :com_artists, :self_refs, :albums_tags, :tags, :albums, :artists].each{|x| DB[x].delete}
+    [:ctis, :cti_subs, :cti_mms, :cti_mm_subs, :stis, :com_self_refs, :com_albums_com_tags, :com_tags, :com_albums, :com_artists, :self_refs, :albums_tags, :tags, :albums, :artists].each{|x| DB[x].delete}
     FixtureDependencies.loaded.clear
     FixtureDependencies.fixtures.clear
   end
@@ -244,5 +244,19 @@ describe FixtureDependencies do
     main.class.must_equal Sty
     sub.class.must_equal StySub
     nl.class.must_equal StySub
+  end
+
+  it "should handle CTI tables correctly" do
+    main, sub, nl = load(:ctis=>[:main, :sub, :nil])
+    main.class.must_equal Cti
+    sub.class.must_equal CtiSub
+    nl.class.must_equal Cti
+  end
+
+  it "should handle CTI tables with model maps correctly" do
+    main, sub, nl = load(:cti_mm=>[:main, :sub, :nil])
+    main.class.must_equal CtiMm
+    sub.class.must_equal CtiMmSub
+    nl.class.must_equal CtiMmSub
   end
 end

--- a/spec/fixtures/cti_mms.yml
+++ b/spec/fixtures/cti_mms.yml
@@ -1,0 +1,12 @@
+main:
+  id: 1
+  kind_id: 2 # CtiMm
+  number: 10
+sub:
+  id: 2
+  kind_id: 1 # CtiMmSub
+  number: 20
+  extra_number: 100
+nil:
+  id: 3
+  number: 30

--- a/spec/fixtures/ctis.yml
+++ b/spec/fixtures/ctis.yml
@@ -1,0 +1,12 @@
+main:
+  id: 1
+  kind: Cti
+  number: 10
+sub:
+  id: 2
+  kind: CtiSub
+  number: 20
+  extra_number: 100
+nil:
+  id: 3
+  number: 30

--- a/spec/migrate/004_cti_tables.rb
+++ b/spec/migrate/004_cti_tables.rb
@@ -1,0 +1,25 @@
+Sequel.migration do
+  change do
+    create_table(:ctis) do
+      primary_key :id
+      String :kind
+      Integer :number
+    end
+
+    create_table(:cti_subs) do
+      primary_key :id
+      Integer :extra_number
+    end
+
+    create_table(:cti_mms) do
+      primary_key :id
+      Integer :kind_id
+      Integer :number
+    end
+
+    create_table(:cti_mm_subs) do
+      primary_key :id
+      Integer :extra_number
+    end
+  end
+end

--- a/spec/sequel_spec_helper.rb
+++ b/spec/sequel_spec_helper.rb
@@ -48,3 +48,17 @@ end
 
 class StySub < Sty
 end
+
+class Cti < Sequel::Model
+  plugin :class_table_inheritance, :key => :kind
+end
+
+class CtiSub < Cti
+end
+
+class CtiMm < Sequel::Model
+	plugin :class_table_inheritance, :key=>:kind_id, :model_map=>{nil=>:CtiMmSub, 1=>:CtiMmSub, 2=>self}, :key_map=>{self=>2, :CtiMmSub=>1}
+end
+
+class CtiMmSub < CtiMm
+end


### PR DESCRIPTION
Prior to 4.24.0, Sequel had a separate interface for supporting CTI.  This adds support for that interface (but remains forward compatible as well with post-4.24.0 sequel)

P.S. - Also turned README into a markdown file to make the github page a little nicer looking