### PR TITLE
Add load_attributes and build methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,33 @@ the loosest coupling possible.  Here's an example:
 Don't worry about loading the same fixture twice, if a fixture is already
 loaded, it won't attempt to load it again.
 
+## Loading attributes only
+
+You can load only the attributes of fixtures, without saving them with
+load\_attributes. This is useful for occasions where you want to mutate
+attributes without having to create lots of fixtures or want to test
+code that is run before or after the database transaction (validations,
+model hooks).
+
+```
+# load_attributes responds like load, but without saving the record
+fruit = load_attributes(:fruit__banana)
+# test the behaviour before saving the record
+fruit.save
+# test the behaviour after saving the record
+```
+
+You can also use the build method for loading the attributes of a
+single record, merging the attributes passed as options. This is useful
+for testing changes in behaviour when mutating a single parameter:
+
+```
+old_banana   = build(:fruit__banana, :age=>'old')
+fresh_banana = build(:fruit__banana, :age=>'new')
+old_banana.must_be :rotten?
+new_banana.wont_be :rotten?
+```
+
 ## one_to_many/many_to_many/has_many/has_and_belongs_to_many assocations
 
 Here's an example of using has_one (logon_information), has_many (assets), and

--- a/lib/fixture_dependencies/rspec/sequel.rb
+++ b/lib/fixture_dependencies/rspec/sequel.rb
@@ -30,4 +30,12 @@ example_group.class_eval do
   def load(*args)
     FixtureDependencies.load(*args)
   end
+
+  def load_attributes(*args)
+    FixtureDependencies.load_attributes(*args)
+  end
+
+  def build(*args)
+    FixtureDependencies.build(*args)
+  end
 end

--- a/lib/fixture_dependencies/test_unit.rb
+++ b/lib/fixture_dependencies/test_unit.rb
@@ -9,6 +9,14 @@ module Test
       def load(*fixture)
         FixtureDependencies.load(*fixture)
       end
+
+      def load_attributes(*args)
+        FixtureDependencies.load_attributes(*args)
+      end
+
+      def build(*args)
+        FixtureDependencies.build(*args)
+      end
     end
   end
 end

--- a/spec/fd_spec.rb
+++ b/spec/fd_spec.rb
@@ -3,6 +3,7 @@ require 'minitest/autorun'
 
 describe FixtureDependencies do
   def load(*a) FixtureDependencies.load(*a) end
+  def load_attributes(*a) FixtureDependencies.load_attributes(*a) end
   def verbose(i=3)
     v = FixtureDependencies.verbose
     FixtureDependencies.verbose = i
@@ -24,12 +25,26 @@ describe FixtureDependencies do
     ym.name.must_equal 'YM'
   end
 
+  it "should load attributes for single records with underscore syntax" do
+    lym = load_attributes(:artist__lym)
+    lym.name.must_equal 'LYM'
+    lym.id.must_be_nil
+  end
+
   it "should load multiple records with underscore syntax and multiple arguments" do
     rf, mo = load(:album__rf, :album__mo) 
     rf.id.must_equal 1
     rf.name.must_equal 'RF'
     mo.id.must_equal 2
     mo.name.must_equal 'MO'
+  end
+
+  it "should load attributes for multiple records with underscore syntax and multiple arguments" do
+    lym, lnu = load_attributes(:artist__lym, :artist__lnu)
+    lym.name.must_equal 'LYM'
+    lym.id.must_equal nil
+    lnu.name.must_equal 'LNU'
+    lnu.id.must_equal nil
   end
 
   it "should load multiple records with hash syntax" do
@@ -40,6 +55,14 @@ describe FixtureDependencies do
     mo.name.must_equal 'MO'
   end
 
+  it "should load attributes for multiple records with hash syntax" do
+    lym, lnu = load_attributes(:artists=>[:lym, :lnu])
+    lym.name.must_equal 'LYM'
+    lym.id.must_equal nil
+    lnu.name.must_equal 'LNU'
+    lnu.id.must_equal nil
+  end
+
   it "should load multiple records with a mix a hashes and symbols" do
     rf, mo = load(:album__rf, :albums=>[:mo]) 
     rf.id.must_equal 1
@@ -48,18 +71,38 @@ describe FixtureDependencies do
     mo.name.must_equal 'MO'
   end
 
+  it "should load attributes for multiple records with a mix a hashes and symbols" do
+    lym, lnu = load_attributes(:artist__lym, :artists=>[:lnu])
+    lym.name.must_equal 'LYM'
+    lym.id.must_equal nil
+    lnu.name.must_equal 'LNU'
+    lnu.id.must_equal nil
+  end
+
   it "should load whole tables at once with single symbol" do
     Artist.count.must_equal 0
     load(:artists) 
-    Artist.count.must_equal 2
+    Artist.count.must_equal 4
+  end
+
+  it "should load attributes for whole tables at once with single symbol" do
+    ym, nu, lym, lnu = load_attributes(:artists)
+    ym.name.must_equal 'YM'
+    ym.id.must_equal 1
+    nu.name.must_equal 'NU'
+    nu.id.must_equal 2
+    lym.name.must_equal 'LYM'
+    lym.id.must_equal nil
+    lnu.name.must_equal 'LNU'
+    lnu.id.must_equal nil
   end
 
   it "should load whole tables at once with single symbol" do
     Artist.count.must_equal 0
     Album.count.must_equal 0
     load(:artists, :albums) 
-    Artist.count.must_equal 2
-    Album.count.must_equal 3
+    Artist.count.must_equal 4
+    Album.count.must_equal 4
   end
 
   it "should load associated many_to_one records" do
@@ -72,6 +115,13 @@ describe FixtureDependencies do
     nu.albums.length.must_equal 1
     nu.albums.first.id.must_equal 3
     nu.albums.first.name.must_equal 'P'
+  end
+
+  it "should load associated many_to_one record when loading attributes" do
+    q = load_attributes(:album__q)
+    q.id.must_equal 4
+    q.name.must_equal 'Q'
+    q.artist.name.must_equal 'LNU'
   end
 
   it "should load associated many_to_many records and handle cycles (I->P->NU->P)" do

--- a/spec/fixtures/albums.yml
+++ b/spec/fixtures/albums.yml
@@ -10,3 +10,7 @@ p:
   id: 3
   name: P
   artist: nu
+q:
+  id: 4
+  name: Q
+  artist: lnu

--- a/spec/fixtures/artists.yml
+++ b/spec/fixtures/artists.yml
@@ -5,3 +5,7 @@ nu:
   id: 2
   name: NU
   albums: p
+lym:
+  name: LYM
+lnu:
+  name: LNU


### PR DESCRIPTION
These methods are useful for:

- When you want to mutate parameters of fixtures explicitly without having to update them after they were created
- Being able to test behaviour of records before they are saved

I tried to make the minimal changes to the existing codebase, so the feaureset is not complete, but is very usable for most cases;

Let me know if there are any pending issues.

Fix #14 