### PR TITLE
Add support file for Minitest::Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ Somewhere before the test code is loaded:
 
 This runs each spec inside a separate Sequel transaction.
 
+### With Minitest/Spec:
+
+Somewhere before the test code is loaded:
+
+```
+  require 'fixture_dependencies/minitest_spec/sequel'
+```
+
+This runs each spec inside a separate Sequel transaction.
+
 ### With other testing libraries:
 
 You can just use FixtureDependencies.load to handle the loading of fixtures.

--- a/lib/fixture_dependencies/minitest_spec.rb
+++ b/lib/fixture_dependencies/minitest_spec.rb
@@ -1,0 +1,15 @@
+require 'fixture_dependencies'
+
+class Minitest::Spec
+  def load(*args)
+    FixtureDependencies.load(*args)
+  end
+
+  def load_attributes(*args)
+    FixtureDependencies.load_attributes(*args)
+  end
+
+  def build(*args)
+    FixtureDependencies.build(*args)
+  end
+end

--- a/lib/fixture_dependencies/minitest_spec/sequel.rb
+++ b/lib/fixture_dependencies/minitest_spec/sequel.rb
@@ -1,0 +1,7 @@
+require 'fixture_dependencies/minitest_spec'
+
+class Minitest::Spec
+  def run(*args, &block)
+    Sequel::Model.db.transaction(:rollback=>:always){super}
+  end
+end


### PR DESCRIPTION
My use case is only for `fixture_dependencies/minitest_spec` but I included the sequel helper as well for completeness.