### PR TITLE
Add the minitest support files to the gemspec

### DIFF
--- a/fixture_dependencies.gemspec
+++ b/fixture_dependencies.gemspec
@@ -1,11 +1,11 @@
 Gem::Specification.new do |s| 
   s.name = "fixture_dependencies"
-  s.version = "1.7.0"
+  s.version = "1.7.1"
   s.author = "Jeremy Evans"
   s.email = "code@jeremyevans.net"
   s.platform = Gem::Platform::RUBY
   s.summary = "Sequel/ActiveRecord fixture loader that handles dependency graphs"
-  s.files = ["README.md", "MIT-LICENSE", "lib/fixture_dependencies.rb", "lib/fixture_dependencies_test_help.rb", "lib/fixture_dependencies/sequel.rb", "lib/fixture_dependencies/active_record.rb", "lib/fixture_dependencies/test_unit.rb", "lib/fixture_dependencies/test_unit/rails.rb", "lib/fixture_dependencies/test_unit/sequel.rb", "lib/fixture_dependencies/rspec/sequel.rb"]
+  s.files = ["README.md", "MIT-LICENSE", "lib/fixture_dependencies.rb", "lib/fixture_dependencies_test_help.rb", "lib/fixture_dependencies/sequel.rb", "lib/fixture_dependencies/active_record.rb", "lib/fixture_dependencies/minitest_spec.rb", "lib/fixture_dependencies/minitest_spec/sequel.rb", "lib/fixture_dependencies/test_unit.rb", "lib/fixture_dependencies/test_unit/rails.rb", "lib/fixture_dependencies/test_unit/sequel.rb", "lib/fixture_dependencies/rspec/sequel.rb"]
   s.extra_rdoc_files = ["MIT-LICENSE"]
   s.require_paths = ["lib"]
   s.has_rdoc = true


### PR DESCRIPTION
The gem does not include the two files added for 1.7.0 with minitest_spec
support. This change remedies that.

% diff -u \
  <(gem contents fixture_dependencies -v 1.7.0 --no-prefix)  \
  <(gem contents fixture_dependencies -v 1.7.1 --no-prefix)

```diff
--- /dev/fd/11	2016-04-22 13:26:04.000000000 -0400
+++ /dev/fd/12	2016-04-22 13:26:04.000000000 -0400
@@ -2,6 +2,8 @@
 README.md
 lib/fixture_dependencies.rb
 lib/fixture_dependencies/active_record.rb
+lib/fixture_dependencies/minitest_spec.rb
+lib/fixture_dependencies/minitest_spec/sequel.rb
 lib/fixture_dependencies/rspec/sequel.rb
 lib/fixture_dependencies/sequel.rb
 lib/fixture_dependencies/test_unit.rb
```