### PR TITLE
Fixes polymorphic dependency load for multiple polymorphic fixtures.

### DIFF
--- a/lib/fixture_dependencies.rb
+++ b/lib/fixture_dependencies.rb
@@ -210,9 +210,11 @@ class << FixtureDependencies
           if polymorphic_association?(value)
             value, polymorphic_class = polymorphic_association(value)
             reflection[:class_name] = polymorphic_class
+            dep_name = "#{polymorphic_class.to_s.underscore}__#{value}".to_sym
+          else
+            dep_name = "#{model_method(:reflection_class, mtype, reflection).name.underscore}__#{value}".to_sym
           end
 
-          dep_name = "#{model_method(:reflection_class, mtype, reflection).name.underscore}__#{value}".to_sym
           if dep_name == record
             # Self referential record, use primary key
             puts "#{spaces}#{record}.#{attr}: belongs_to self-referential" if verbose > 1

--- a/spec/fd_spec.rb
+++ b/spec/fd_spec.rb
@@ -338,5 +338,13 @@ if defined?(Account) && defined?(Address)
       account = address.addressable
       account.name.must_equal "John Smith"
     end
+
+    it "should handle more than 1 polymorphic correctly" do
+      address = load(:address__lym_address)
+      address.street.must_equal "123 Walnut Street - Moe's Tavern"
+
+      artist = address.addressable
+      artist.name.must_equal "LYM"
+    end
   end
 end

--- a/spec/fixtures/addresses.yml
+++ b/spec/fixtures/addresses.yml
@@ -2,3 +2,7 @@ john_address:
   addressable: john (Account)
   street: 743 Evergreen Boulevard
   city: Springfield
+lym_address:
+  addressable: lym (Artist)
+  street: 123 Walnut Street - Moe's Tavern
+  city: Springfield

--- a/spec/sequel_spec_helper.rb
+++ b/spec/sequel_spec_helper.rb
@@ -71,6 +71,11 @@ begin
     one_to_many :addresses, :as => :addressable
   end
 
+  class Artist < Sequel::Model
+    plugin :polymorphic
+    one_to_many :addresses, :as => :addressable
+  end
+
   class Address < Sequel::Model
     plugin :polymorphic
     many_to_one :addressable, :polymorphic => true


### PR DESCRIPTION
When having more than 1 polymorphic fixture at the same file, this fixture assumes the last polymorphic model class. Before this fix, the error was: 

```
  1) Error:
FixtureDependencies#test_0040_should handle more than 1 polymorphic correctly:
Sequel::Error: Couldn't use fixture :account__lym
    /home/wjsantos/www/fixture_dependencies/lib/fixture_dependencies/sequel.rb:26:in `raise_model_error_S'
    /home/wjsantos/www/fixture_dependencies/lib/fixture_dependencies.rb:130:in `model_method'
    /home/wjsantos/www/fixture_dependencies/lib/fixture_dependencies.rb:177:in `use'
    /home/wjsantos/www/fixture_dependencies/lib/fixture_dependencies.rb:244:in `block in use'
    /home/wjsantos/www/fixture_dependencies/lib/fixture_dependencies.rb:205:in `each'
    /home/wjsantos/www/fixture_dependencies/lib/fixture_dependencies.rb:205:in `use'
    /home/wjsantos/www/fixture_dependencies/lib/fixture_dependencies.rb:66:in `block in load_with_options'
    /home/wjsantos/www/fixture_dependencies/lib/fixture_dependencies.rb:63:in `map'
    /home/wjsantos/www/fixture_dependencies/lib/fixture_dependencies.rb:63:in `load_with_options'
    /home/wjsantos/www/fixture_dependencies/lib/fixture_dependencies.rb:34:in `load'
    spec/fd_spec.rb:5:in `load'
    spec/fd_spec.rb:343:in `block (2 levels) in <main>'
```

`Lym` is an `Artist`, not an `Account`.