### PR TITLE
Move shared load and build methods to module

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ FixtureDependencies:
   FixtureDependencies.fixture_path = '/path/to/fixtures'
 ```
 
+A few helper methods are also available, just include them in your test superclass:
+
+```
+  require 'fixture_dependencies/helper_methods'
+
+  class Test < Minitest::Test
+    include FixtureDependencies::HelperMethods
+  end
+```
+
 ## Changes to Rails default fixtures:
 
 fixture_dependencies is designed to require the least possible changes to

--- a/lib/fixture_dependencies/helper_methods.rb
+++ b/lib/fixture_dependencies/helper_methods.rb
@@ -1,0 +1,18 @@
+require 'fixture_dependencies'
+
+class FixtureDependencies
+  module HelperMethods
+    # Load given fixtures using FixtureDependencies
+    def load(*fixture)
+      FixtureDependencies.load(*fixture)
+    end
+
+    def load_attributes(*args)
+      FixtureDependencies.load_attributes(*args)
+    end
+
+    def build(*args)
+      FixtureDependencies.build(*args)
+    end
+  end
+end

--- a/lib/fixture_dependencies/minitest_spec.rb
+++ b/lib/fixture_dependencies/minitest_spec.rb
@@ -1,15 +1,5 @@
-require 'fixture_dependencies'
+require 'fixture_dependencies/helper_methods'
 
 class Minitest::Spec
-  def load(*args)
-    FixtureDependencies.load(*args)
-  end
-
-  def load_attributes(*args)
-    FixtureDependencies.load_attributes(*args)
-  end
-
-  def build(*args)
-    FixtureDependencies.build(*args)
-  end
+  include FixtureDependencies::HelperMethods
 end

--- a/lib/fixture_dependencies/test_unit.rb
+++ b/lib/fixture_dependencies/test_unit.rb
@@ -1,22 +1,11 @@
-require 'fixture_dependencies'
+require 'fixture_dependencies/helper_methods'
 
 module Test
   module Unit
     class TestCase
       private
-      
-      # Load given fixtures using FixtureDependencies
-      def load(*fixture)
-        FixtureDependencies.load(*fixture)
-      end
 
-      def load_attributes(*args)
-        FixtureDependencies.load_attributes(*args)
-      end
-
-      def build(*args)
-        FixtureDependencies.build(*args)
-      end
+      include FixtureDependencies::HelperMethods
     end
   end
 end


### PR DESCRIPTION
I'm using `Minitest::Test` and it's easier than copy/pasting them to every project.