### PR TITLE
Allow strings to be used as model names in the class map

### DIFF
--- a/lib/fixture_dependencies.rb
+++ b/lib/fixture_dependencies.rb
@@ -148,7 +148,12 @@ class << FixtureDependencies
   # can be overridden by <tt>FixtureDependencies.class_map[:name] =
   # Some::Class</tt>.
   def model_class(model_name)
-    class_map[model_name.to_sym] || model_name.camelize.constantize
+    if class_map.has_key?(model_name.to_sym)
+      klass = class_map[model_name.to_sym]
+      klass.respond_to?(:constantize) ? klass.constantize : klass
+    else
+      model_name.camelize.constantize
+    end
   end
 
   # Split the fixture name into the name of the model and the name of


### PR DESCRIPTION
The model may not be defined at the time the class map is defined.