### PR TITLE
Cyclic dependency unique constraint violation

### DIFF
--- a/lib/fixture_dependencies.rb
+++ b/lib/fixture_dependencies.rb
@@ -62,6 +62,9 @@ class FixtureDependencies
       end
     end.flatten.compact.map do |record| 
       model_name, name = split_name(record)
+      unless class_map[model_name.to_sym].nil?
+        record = "#{class_map[model_name.to_sym].to_s.underscore}__#{name}"
+      end
       if name
         use(record.to_sym, opts)
       else


### PR DESCRIPTION
When there are recursive relationships between models, accessing them with their class map model name will result in the same record being inserted into the table twice. In cases where the fixture includes a unique column, an exception will be raised.

This converts all class mapped model names to their full name to begin with, which will prevent that error from occurring.

I've created [a gist reproducing the issue](https://gist.github.com/rintaun/9e8b1f293be2af94b3e2572f68cce17f).