### PR TITLE
Remove setting class_name in polymorphic association

### DIFF
--- a/lib/fixture_dependencies.rb
+++ b/lib/fixture_dependencies.rb
@@ -213,7 +213,6 @@ class << FixtureDependencies
 
           if polymorphic_association?(value)
             value, polymorphic_class = polymorphic_association(value)
-            reflection[:class_name] = polymorphic_class
             dep_name = "#{polymorphic_class.to_s.underscore}__#{value}".to_sym
           else
             dep_name = "#{model_method(:reflection_class, mtype, reflection).name.underscore}__#{value}".to_sym

--- a/spec/fd_spec.rb
+++ b/spec/fd_spec.rb
@@ -187,6 +187,39 @@ describe FixtureDependencies do
     cm.name.must_equal "CM"
   end
 
+  if defined?(Account) && defined?(Address)
+    it "should handle normal fixture correctly" do
+      account = load(:account__john)
+      account.name.must_equal "John Smith"
+    end
+
+    it "should handle polymorphic one_to_many correctly" do
+      account = load(:account__john)
+      account.name.must_equal "John Smith"
+
+      address = load(:address__john_address)
+      address.street.must_equal "743 Evergreen Boulevard"
+
+      account.addresses.must_equal [address]
+    end
+
+    it "should handle polymorphic many_to_one correctly" do
+      address = load(:address__john_address)
+      address.street.must_equal "743 Evergreen Boulevard"
+
+      account = address.addressable
+      account.name.must_equal "John Smith"
+    end
+
+    it "should handle more than 1 polymorphic correctly" do
+      address = load(:address__lym_address)
+      address.street.must_equal "123 Walnut Street - Moe's Tavern"
+
+      artist = address.addressable
+      artist.name.must_equal "LYM"
+    end
+  end
+
   next if ENV['FD_AR']
 
   it "should load single records with underscore syntax" do
@@ -329,38 +362,5 @@ describe FixtureDependencies do
   it "should handle models with fixture_filename defined" do
     rf = load(:artist_custom_fixture__ym)
     rf.name.must_equal "YMCUSTOM"
-  end
-
-if defined?(Account) && defined?(Address)
-    it "should handle normal fixture correctly" do
-      account = load(:account__john)
-      account.name.must_equal "John Smith"
-    end
-
-    it "should handle polymorphic one_to_many correctly" do
-      account = load(:account__john)
-      account.name.must_equal "John Smith"
-
-      address = load(:address__john_address)
-      address.street.must_equal "743 Evergreen Boulevard"
-
-      account.addresses.must_equal [address]
-    end
-
-    it "should handle polymorphic many_to_one correctly" do
-      address = load(:address__john_address)
-      address.street.must_equal "743 Evergreen Boulevard"
-
-      account = address.addressable
-      account.name.must_equal "John Smith"
-    end
-
-    it "should handle more than 1 polymorphic correctly" do
-      address = load(:address__lym_address)
-      address.street.must_equal "123 Walnut Street - Moe's Tavern"
-
-      artist = address.addressable
-      artist.name.must_equal "LYM"
-    end
   end
 end


### PR DESCRIPTION
Hi Jeremy, firstly thank you very much for this gem. It's really helpful for me.

There is an issue with the polymorphic association on newer version of the ActiveRecord. It raised this error

```
NoMethodError: undefined method `[]=' for #<ActiveRecord::Reflection::AssociationReflection:0x007f809c9af0f0>
    /Users/alecksdang/Documents/Projects/fixture_dependencies/lib/fixture_dependencies.rb:216:in `block in use'
    /Users/alecksdang/Documents/Projects/fixture_dependencies/lib/fixture_dependencies.rb:209:in `each'
    /Users/alecksdang/Documents/Projects/fixture_dependencies/lib/fixture_dependencies.rb:209:in `use'
    /Users/alecksdang/Documents/Projects/fixture_dependencies/lib/fixture_dependencies.rb:69:in `block in load_with_options'
    /Users/alecksdang/Documents/Projects/fixture_dependencies/lib/fixture_dependencies.rb:63:in `map'
    /Users/alecksdang/Documents/Projects/fixture_dependencies/lib/fixture_dependencies.rb:63:in `load_with_options'
    /Users/alecksdang/Documents/Projects/fixture_dependencies/lib/fixture_dependencies.rb:34:in `load'
    spec/fd_spec.rb:8:in `load'
    spec/fd_spec.rb:215:in `block (2 levels) in <main>'
```

I don't think we need to do `reflection[:class_name] = polymorphic_class` anymore, since ActiveRecord will automatically handled that. I have tested this against ActiveRecord version 3 (3.2.0), 4 (4.1.0), and also 5 (5.2.3) not version 2 because I think it might be too old, btw if you are interested I have some tests using (Appraisal) to test against multiple ActiveRecord versions.