### PR TITLE
Raise invalid record with better error

### DIFF
--- a/lib/fixture_dependencies/active_record.rb
+++ b/lib/fixture_dependencies/active_record.rb
@@ -18,7 +18,7 @@ class << FixtureDependencies
   end
   
   def model_save_AR(object)
-    object.save || raise(ActiveRecord::ActiveRecordError)
+    object.save || raise(ActiveRecord::RecordInvalid, object)
   end
   
   def raise_model_error_AR(message)

--- a/spec/ar_spec_helper.rb
+++ b/spec/ar_spec_helper.rb
@@ -31,6 +31,7 @@ end
 
 class Address < ActiveRecord::Base
   belongs_to :addressable, :polymorphic => true
+  validates :street, presence: true
 end
 
 module ClassMap; end

--- a/spec/fd_spec.rb
+++ b/spec/fd_spec.rb
@@ -218,6 +218,11 @@ describe FixtureDependencies do
       artist = address.addressable
       artist.name.must_equal "LYM"
     end
+
+    it "should raise error with better message" do
+      err = proc { load(:address__invalid_address) }.must_raise(ActiveRecord::RecordInvalid)
+      err.message.must_match "Validation failed: Street can't be blank"
+    end
   end
 
   next if ENV['FD_AR']

--- a/spec/fixtures/addresses.yml
+++ b/spec/fixtures/addresses.yml
@@ -2,7 +2,11 @@ john_address:
   addressable: john (Account)
   street: 743 Evergreen Boulevard
   city: Springfield
+
 lym_address:
   addressable: lym (Artist)
   street: 123 Walnut Street - Moe's Tavern
   city: Springfield
+
+invalid_address:
+  addressable: john (Account)


### PR DESCRIPTION
Hi 👋 , this PR here is to improve the error message just a bit clearer. So whenever the `fixture` failed to save, it just plainly raised `ActiveRecord::ActiveRecordError` alone so it was a bit difficult to actually debug whether which caused it to happen. So I improved the error to be looking like this 

`ActiveRecord::RecordInvalid: Validation failed: Email (blah@gmail.com) has already been taken`.

Which gives us much better context.