### PR TITLE
Add `use_unsafe_load` setting

### DIFF
--- a/spec/fd_spec.rb
+++ b/spec/fd_spec.rb
@@ -1346,6 +1346,21 @@ describe FixtureDependencies do
     ]
   end
 
+  it "should handle dates and times without quote marks" do
+    FixtureDependencies.use_unsafe_load = true
+
+    prd = load(:producer__prd)
+    prd.created_at.must_be_instance_of Time
+    prd.date_of_birth.must_be_instance_of Date
+    check_output [
+      "using producer__prd",
+      "load stack:[]",
+      "loading producers.yml"
+    ]
+  ensure
+    FixtureDependencies.use_unsafe_load = false
+  end
+
   it "should raise error for invalid fixture" do
     proc{load(:album__nonexistant)}.must_raise(defined?(Sequel::Error) ? Sequel::Error : ActiveRecord::RecordNotFound)
     check_output [

--- a/spec/fixtures/producers.yml
+++ b/spec/fixtures/producers.yml
@@ -1,0 +1,5 @@
+prd:
+  id: 1
+  name: PRD
+  date_of_birth: 2024-1-1
+  created_at: 2021-02-16 18:00:00

--- a/spec/migrate/006_producers_table.rb
+++ b/spec/migrate/006_producers_table.rb
@@ -1,0 +1,10 @@
+Sequel.migration do
+  change do
+    create_table(:producers) do
+      primary_key :id
+      String :name
+      Date :date_of_birth
+      DateTime :created_at
+    end
+  end
+end

--- a/spec/sequel_spec_helper.rb
+++ b/spec/sequel_spec_helper.rb
@@ -23,6 +23,8 @@ class Name::Tag < Sequel::Model
   many_to_many :albums, :order=>Sequel.desc(:id), :class => Album
 end
 
+class Producer < Sequel::Model; end
+
 class SelfRef < Sequel::Model
   many_to_one :self_ref
   one_to_many :self_refs


### PR DESCRIPTION
Since Ruby 3.1, Psyche (the gem in charge of parsing YAMLs) tries parses certain string patterns as `Date` or `Time` objects, but fails to instantiate them if those classes are not explicitly allowed, or you use `unsafe_load` instead of `load`.

With this change users of `fixture_dependencies` can opt in to the `unsafe_load` way of solving this issue.

Co-Authored-By: Jeremy Evans <code@jeremyevans.net>

Closes: https://github.com/jeremyevans/fixture_dependencies/issues/37